### PR TITLE
fix wording 'Ersatzbenutzer'

### DIFF
--- a/src/plugins/system/jtchuserbeforedel/language/de-DE/de-DE.plg_system_jtchuserbeforedel.sys.ini
+++ b/src/plugins/system/jtchuserbeforedel/language/de-DE/de-DE.plg_system_jtchuserbeforedel.sys.ini
@@ -15,6 +15,6 @@ PLG_SYSTEM_JTCHUSERBEFOREDEL_FALLBACK_ALIAS_NAME_DESC="Der Ersatzalias wird verw
 
 PLG_SYSTEM_JTCHUSERBEFOREDEL_BATCH_NOTE_DESC="Nachfolgende Felder dienen nur der Korrektur bereits gelöschte Benutzer."
 PLG_SYSTEM_JTCHUSERBEFOREDEL_USER_ID_TO_CHANGE_MANUALY_LABEL="Suche Benutzer ID"
-PLG_SYSTEM_JTCHUSERBEFOREDEL_USER_ID_TO_CHANGE_MANUALY_DESC="Die hier eingegebene Benutzer ID wird gesucht und durch den Austauschbenutzer ersetzt."
+PLG_SYSTEM_JTCHUSERBEFOREDEL_USER_ID_TO_CHANGE_MANUALY_DESC="Die hier eingegebene Benutzer ID wird gesucht und durch den Ersatzbenutzer ersetzt."
 PLG_SYSTEM_JTCHUSERBEFOREDEL_USER_NAME_TO_CHANGE_MANUALY_LABEL="Name (Autoralias)"
 PLG_SYSTEM_JTCHUSERBEFOREDEL_USER_NAME_TO_CHANGE_MANUALY_DESC="Soll ein Autoralias eingetragen werden, wird dieser Name verwendet. Der Ersatzalias wird ignoriert. <br />Leer lassen, wenn kein Autoralias eingetragen werden soll, oder ein Bestehender gelöscht werden soll (Autoralias überschreiben: Ja)."


### PR DESCRIPTION
This PR standardises the term for ‘Ersatzbenutzer’.
see https://github.com/joomtools/plg_system_jtchuserbeforedel/blob/74bccb4fe761ece6da921f876343939837c98242/src/plugins/system/jtchuserbeforedel/language/de-DE/de-DE.plg_system_jtchuserbeforedel.sys.ini#L4